### PR TITLE
Update build.gradle

### DIFF
--- a/weekdaysselector/build.gradle
+++ b/weekdaysselector/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
+    implementation 'com.github.ramseth001:TextDrawable:1.1.3'
 
     implementation 'androidx.legacy:legacy-support-v13:1.0.0'
 }


### PR DESCRIPTION
Changed Textdrawable Library. Previous one uses JCenter which will soon shut down.